### PR TITLE
Added cmake_installer package as build dependency

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -14,6 +14,7 @@ class SDL2Conan(ConanFile):
     exports = ["LICENSE.md"]
     exports_sources = ["CMakeLists.txt"]
     generators = ['cmake']
+    build_requires = "cmake_installer/[>2.8.11]@conan/stable"
     source_subfolder = "source_subfolder"
     build_subfolder = "build_subfolder"
     settings = "os", "arch", "compiler", "build_type"


### PR DESCRIPTION
This package uses CMake as build system however it doesn't listed in build_requires of package. Some systems doesn't have CMake binary in PATH environment variable (or doesn't have CMake at all) and package build fails in this case.