### PR TITLE
Fix sdl2-config behavior by restoring libSDL2.so

### DIFF
--- a/cmake.patch
+++ b/cmake.patch
@@ -1,0 +1,56 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8f1e828..96ca868 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -47,11 +47,7 @@ set(SDL_INTERFACE_AGE 0)
+ set(SDL_BINARY_AGE 8)
+ set(SDL_VERSION "${SDL_MAJOR_VERSION}.${SDL_MINOR_VERSION}.${SDL_MICRO_VERSION}")
+ 
+-# Set defaults preventing destination file conflicts
+-set(SDL_CMAKE_DEBUG_POSTFIX "d"
+-    CACHE STRING "Name suffix for debug builds")
+-
+-mark_as_advanced(CMAKE_IMPORT_LIBRARY_SUFFIX SDL_CMAKE_DEBUG_POSTFIX)
++mark_as_advanced(CMAKE_IMPORT_LIBRARY_SUFFIX)
+ 
+ # Calculate a libtool-like version number
+ math(EXPR LT_CURRENT "${SDL_MICRO_VERSION} - ${SDL_INTERFACE_AGE}")
+@@ -1697,9 +1693,6 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EXTRA_CFLAGS}")
+ add_library(SDL2main STATIC ${SDLMAIN_SOURCES})
+ target_include_directories(SDL2main PUBLIC $<INSTALL_INTERFACE:include>)
+ set(_INSTALL_LIBS "SDL2main")
+-if (NOT ANDROID)
+-  set_target_properties(SDL2main PROPERTIES DEBUG_POSTFIX ${SDL_CMAKE_DEBUG_POSTFIX})
+-endif()
+ 
+ if(SDL_SHARED)
+   add_library(SDL2 SHARED ${SOURCE_FILES} ${VERSION_SOURCES})
+@@ -1725,9 +1718,6 @@ if(SDL_SHARED)
+   set(_INSTALL_LIBS "SDL2" ${_INSTALL_LIBS})
+   target_link_libraries(SDL2 ${EXTRA_LIBS} ${EXTRA_LDFLAGS})
+   target_include_directories(SDL2 PUBLIC $<INSTALL_INTERFACE:include>)
+-  if (NOT ANDROID)
+-    set_target_properties(SDL2 PROPERTIES DEBUG_POSTFIX ${SDL_CMAKE_DEBUG_POSTFIX})
+-  endif()
+ endif()
+ 
+ if(SDL_STATIC)
+@@ -1751,9 +1741,6 @@ if(SDL_STATIC)
+   set(_INSTALL_LIBS "SDL2-static" ${_INSTALL_LIBS})
+   target_link_libraries(SDL2-static ${EXTRA_LIBS} ${EXTRA_LDFLAGS})
+   target_include_directories(SDL2-static PUBLIC $<INSTALL_INTERFACE:include>)
+-  if (NOT ANDROID)
+-    set_target_properties(SDL2-static PROPERTIES DEBUG_POSTFIX ${SDL_CMAKE_DEBUG_POSTFIX})
+-  endif()
+ endif()
+ 
+ ##### Tests #####
+@@ -1819,7 +1806,7 @@ if(NOT (WINDOWS OR CYGWIN))
+         install(CODE "
+           execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+           \"libSDL2-2.0.${SOEXT}\" \"libSDL2.${SOEXT}\")")
+-        install(FILES ${SDL2_BINARY_DIR}/libSDL2.${SOEXT} DESTINATION "lib${LIB_SUFFIX}")
++        install(FILES ${CMAKE_BINARY_DIR}/libSDL2.${SOEXT} DESTINATION "lib${LIB_SUFFIX}")
+     endif()
+   endif()
+   if(FREEBSD)

--- a/cmake.patch
+++ b/cmake.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 8f1e828..96ca868 100644
+index 8f1e828..c6b1723 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -47,11 +47,7 @@ set(SDL_INTERFACE_AGE 0)
@@ -45,7 +45,12 @@ index 8f1e828..96ca868 100644
  endif()
  
  ##### Tests #####
-@@ -1819,7 +1806,7 @@ if(NOT (WINDOWS OR CYGWIN))
+@@ -1815,11 +1802,11 @@ if(NOT (WINDOWS OR CYGWIN))
+     else()
+         set(SOEXT "so")
+     endif()
+-    if(NOT ANDROID)
++    if(NOT (ANDROID OR APPLE))
          install(CODE "
            execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
            \"libSDL2-2.0.${SOEXT}\" \"libSDL2.${SOEXT}\")")

--- a/conanfile.py
+++ b/conanfile.py
@@ -16,8 +16,8 @@ class SDL2Conan(ConanFile):
     exports = ["LICENSE.md"]
     exports_sources = ["CMakeLists.txt", "cmake.patch"]
     generators = ['cmake']
-    source_subfolder = "source_subfolder"
-    build_subfolder = "build_subfolder"
+    _source_subfolder = "source_subfolder"
+    _build_subfolder = "build_subfolder"
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False],
                "fPIC": [True, False],
@@ -196,8 +196,8 @@ class SDL2Conan(ConanFile):
         source_url = "https://www.libsdl.org/release/SDL2-%s.tar.gz" % self.version
         tools.get(source_url)
         extracted_dir = "SDL2-" + self.version
-        os.rename(extracted_dir, self.source_subfolder)
-        tools.patch(base_path=self.source_subfolder, patch_file="cmake.patch")
+        os.rename(extracted_dir, self._source_subfolder)
+        tools.patch(base_path=self._source_subfolder, patch_file="cmake.patch")
 
     def build(self):
         if self.settings.compiler == 'Visual Studio':
@@ -265,7 +265,7 @@ class SDL2Conan(ConanFile):
         elif self.settings.os == "Windows":
             cmake.definitions["DIRECTX"] = self.options.directx
 
-        cmake.configure(build_dir=self.build_subfolder)
+        cmake.configure(build_dir=os.path.join(self.build_folder, self._build_subfolder))
         return cmake
 
     def build_cmake(self):
@@ -274,8 +274,8 @@ class SDL2Conan(ConanFile):
 
     def package(self):
         cmake = self.configure_cmake()
-        cmake.install()
-        self.copy(pattern="COPYING.txt", dst="license", src=self.source_subfolder)
+        cmake.install(build_dir=os.path.join(self.build_folder, self._build_subfolder))
+        self.copy(pattern="COPYING.txt", dst="license", src=self._source_subfolder)
         if self.settings.compiler == 'Visual Studio':
             self.copy(pattern="*.pdb", dst="lib", src=".")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,7 @@ class SDL2Conan(ConanFile):
     author = "Bincrafters <bincrafters@gmail.com>"
     license = "LGPL-2.1"
     exports = ["LICENSE.md"]
-    exports_sources = ["CMakeLists.txt"]
+    exports_sources = ["CMakeLists.txt", "cmake.patch"]
     generators = ['cmake']
     source_subfolder = "source_subfolder"
     build_subfolder = "build_subfolder"
@@ -197,10 +197,7 @@ class SDL2Conan(ConanFile):
         tools.get(source_url)
         extracted_dir = "SDL2-" + self.version
         os.rename(extracted_dir, self.source_subfolder)
-        tools.replace_in_file(
-                os.path.join(self.source_subfolder, 'CMakeLists.txt'),
-                'install(FILES ${SDL2_BINARY_DIR}/libSDL2.${SOEXT} DESTINATION "lib${LIB_SUFFIX}")',
-                '')
+        tools.patch(base_path=self.source_subfolder, patch_file="cmake.patch")
 
     def build(self):
         if self.settings.compiler == 'Visual Studio':
@@ -301,7 +298,7 @@ class SDL2Conan(ConanFile):
         sdl2_config = os.path.join(self.package_folder, 'bin', sdl2_config)
         self.output.info('Creating SDL2_CONFIG environment variable: %s' % sdl2_config)
         self.env_info.SDL2_CONFIG = sdl2_config
-        self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.libs = [lib for lib in tools.collect_libs(self) if '2.0' not in lib]
         if not self.options.sdl2main:
             self.cpp_info.libs = [lib for lib in self.cpp_info.libs if 'main' not in lib]
         self.cpp_info.includedirs.append(os.path.join('include', 'SDL2'))


### PR DESCRIPTION
There is a bug in SDL2's CMakeLists.txt which tries to copy libSDL2.so
from an incorrect location. This behavior had previously been patched
out, which had the unfortunate side effect of breaking the behavior of
sdl2-config. This behavior has been corrected.