### PR TITLE
Added workaround for implicit memset

### DIFF
--- a/SDL_string.patch
+++ b/SDL_string.patch
@@ -1,0 +1,18 @@
+--- a/src/stdlib/SDL_string.c	2019-07-25 06:32:36.000000000 +0200
++++ b/src/stdlib/SDL_string.c	2019-08-11 14:23:08.406453900 +0200
+@@ -311,6 +311,15 @@
+ #endif /* HAVE_MEMSET */
+ }
+ 
++#if !defined(HAVE_MEMSET)
++#pragma function(memset)
++void *
++memset(void *dst, int c, size_t len)
++{
++    return SDL_memset(dst, c, len);
++}
++#endif /* HAVE_MEMSET */
++
+ void *
+ SDL_memcpy(SDL_OUT_BYTECAP(len) void *dst, SDL_IN_BYTECAP(len) const void *src, size_t len)
+ {

--- a/conanfile.py
+++ b/conanfile.py
@@ -13,7 +13,7 @@ class SDL2Conan(ConanFile):
     author = "Bincrafters <bincrafters@gmail.com>"
     license = "Zlib"
     exports = ["LICENSE.md"]
-    exports_sources = ["CMakeLists.txt", "cmake.patch"]
+    exports_sources = ["CMakeLists.txt", "cmake.patch", "SDL_string.patch"]
     generators = ['cmake']
     _source_subfolder = "source_subfolder"
     _build_subfolder = "build_subfolder"
@@ -202,6 +202,9 @@ class SDL2Conan(ConanFile):
         extracted_dir = "SDL2-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
         tools.patch(base_path=self._source_subfolder, patch_file="cmake.patch")
+        # Workaround for linker error with VS2019, see https://bugzilla.libsdl.org/show_bug.cgi?id=4759
+        if self.settings.compiler == 'Visual Studio' and self.settings.compiler.version == 16:
+            tools.patch(base_path=self._source_subfolder, patch_file="SDL_string.patch")
 
     def build(self):
         # ensure sdl2-config is created for MinGW


### PR DESCRIPTION
This was breaking the build going from VS2019 Version 14.21.27702 to 14.22.27905.
I've also filed a bug for this upstream: https://bugzilla.libsdl.org/show_bug.cgi?id=4759