### PR TITLE
Fix generator output for SCons on macOS

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -345,7 +345,8 @@ class SDL2Conan(ConanFile):
         elif self.settings.os == "Macos":
             frameworks = ['Cocoa', 'Carbon', 'IOKit', 'CoreVideo', 'CoreAudio', 'AudioToolbox', 'ForceFeedback']
             for framework in frameworks:
-                self.cpp_info.exelinkflags.append("-framework %s" % framework)
+                self.cpp_info.exelinkflags.append("-framework")
+                self.cpp_info.exelinkflags.append(framework)
             if not self.options.iconv:
                 self.cpp_info.libs.append('iconv')
             self.cpp_info.sharedlinkflags = self.cpp_info.exelinkflags


### PR DESCRIPTION
When generating `-framework` linker flags, make sure that the option and its argument are appended as separate command-line arguments. Otherwise, some generators such as the SCons ones try to pass e.g. `-framework Cocoa` as one single argument, resulting in compiler errors.