### PR TITLE
Can pick whether to use conan or system variant of most dependencies

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -37,6 +37,7 @@ class SDL2Conan(ConanFile):
         "video_rpi": [True, False],
         "sdl2main": [True, False],
         "gl": ["mesa", "system"],
+        "drm": [True, False],
     }
     default_options = {
         "shared": False,

--- a/conanfile.py
+++ b/conanfile.py
@@ -61,6 +61,7 @@ class SDL2Conan(ConanFile):
         "iconv": True,
         "video_rpi": False,
         "sdl2main": True,
+        "drm": False,
         "gl": "system",
     }
 
@@ -73,7 +74,8 @@ class SDL2Conan(ConanFile):
             self.requires.add("libiconv/1.16")
 
         if self.settings.os == "Linux" and tools.os_info.is_linux:
-            self.requires.add("libdrm/2.4.100@bincrafters/stable")
+            if self.options.drm:
+                self.requires.add("libdrm/2.4.100@bincrafters/stable")
             if not tools.which('pkg-config'):
                 self.requires.add("pkg-config_installer/0.29.2@bincrafters/stable")
             if self.options.alsa == "conan":


### PR DESCRIPTION
After you moved those system dependencies to conan, my game did not run anymore. I think most of these are "driver" level, specifically build for the end-users computer, or in the case of OpenGL, there's even completely different libraries conforming to the same ABI (e.g. closed-source NVidia drivers vs. mesa).
I've added options switch between the system or conan variants, so everyone can be happy.