### PR TITLE
Add a few missing options...

### DIFF
--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -1,4 +1,4 @@
-# bincrafters-conventions:gha-workflow-version:4
+# bincrafters-conventions:gha-workflow-version:6
 # You can add custom environment variables above the version tag
 # Do not modify the tag or anything below the tag
 # This script gets automatically updated
@@ -6,63 +6,46 @@
 # Possible configurations:
 # env:
 #   splitByBuildTypes: "false"  # Possible values "false", "true", default: false
-#   recipeType: "" # Possible values "" (for libraries), "header_only", "installer": default ""
-
-# - IMPORTANT NOTICE: These configurations are actually not completely working as expected yet due to GHA limitations
-# but it is important to set this values already so they can be consumed later
 
 # You can furthermore set any environment variable understood by Conan and Conan Package Tools
 
 on: [push, pull_request]
 
 jobs:
-  conan:
-    runs-on: ${{ matrix.config.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - { name: "GCC 4.9 Debug", compiler: "GCC", version: "4.9", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
-          - { name: "GCC 4.9 Release", compiler: "GCC", version: "4.9", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
-          - { name: "GCC 5 Debug", compiler: "GCC", version: "5", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
-          - { name: "GCC 5 Release", compiler: "GCC", version: "5", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
-          - { name: "GCC 6 Debug", compiler: "GCC", version: "6", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
-          - { name: "GCC 6 Release", compiler: "GCC", version: "6", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
-          - { name: "GCC 7 Debug", compiler: "GCC", version: "7", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
-          - { name: "GCC 7 Release", compiler: "GCC", version: "7", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
-          - { name: "GCC 8 Debug", compiler: "GCC", version: "8", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
-          - { name: "GCC 8 Release", compiler: "GCC", version: "8", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
-          - { name: "GCC 9 Debug", compiler: "GCC", version: "9", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
-          - { name: "GCC 9 Release", compiler: "GCC", version: "9", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
-          - { name: "CLANG 3.9 Debug", compiler: "CLANG", version: "3.9", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
-          - { name: "CLANG 3.9 Release", compiler: "CLANG", version: "3.9", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
-          - { name: "CLANG 4.0 Debug", compiler: "CLANG", version: "4.0", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
-          - { name: "CLANG 4.0 Release", compiler: "CLANG", version: "4.0", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
-          - { name: "CLANG 5.0 Debug", compiler: "CLANG", version: "5.0", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
-          - { name: "CLANG 5.0 Release", compiler: "CLANG", version: "5.0", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
-          - { name: "CLANG 6.0 Debug", compiler: "CLANG", version: "6.0", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
-          - { name: "CLANG 6.0 Release", compiler: "CLANG", version: "6.0", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
-          - { name: "CLANG 7.0 Debug", compiler: "CLANG", version: "7.0", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
-          - { name: "CLANG 7.0 Release", compiler: "CLANG", version: "7.0", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
-          - { name: "CLANG 8 Debug", compiler: "CLANG", version: "8", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
-          - { name: "CLANG 8 Release", compiler: "CLANG", version: "8", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
-          - { name: "CLANG 9 Debug", compiler: "CLANG", version: "9", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
-          - { name: "CLANG 9 Release", compiler: "CLANG", version: "9", os: "ubuntu-18.04", buildType: "Release", recipeType: ""  }
-          - { name: "Header-only Linux", compiler: "CLANG", version: "8", os: "ubuntu-18.04", recipeType: "header_only" }
-          - { name: "Header-only Windows", compiler: "VISUAL", version: "16", os: "windows-latest", recipeType: "header_only" }
-          - { name: "Installer Linux", compiler: "GCC", version: "7", os: "ubuntu-18.04", dockerImage: "conanio/gcc7-centos6", recipeType: "installer" }
-          - { name: "Installer Windows", compiler: "VISUAL", version: "16", os: "windows-2019", recipeType: "installer" }
-          - { name: "Installer macOS", compiler: "APPLE_CLANG", version: "11.0", os: "macos-10.15", recipeType: "installer" }
-    name: ${{ matrix.config.name }}
-    # # FIXME: GHA will support accessing env variables here in the future
-    # if: (env.splitByBuildTypes != 'true' or matrix.buildType != '') and env.recipeType == matrix.config.recipeType
+  generate-matrix:
+    name: Generate Job Matrix
+    runs-on: ubuntu-18.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v2
-        if: env.recipeType == matrix.config.recipeType
       - uses: actions/setup-python@v1
         with:
           python-version: "3.8"
-        if: env.recipeType == matrix.config.recipeType
+      - name: Install Package Tools
+        run: |
+          pip install bincrafters_package_tools
+          conan user
+      - name: Generate Job Matrix
+        id: set-matrix
+        env:
+          splitByBuildTypes: ${{ env.splitByBuildTypes }}
+        run: |
+          MATRIX=$(bincrafters-package-tools generate-ci-jobs --platform gha)
+          echo "${MATRIX}"
+          echo "::set-output name=matrix::${MATRIX}"
+  conan:
+    needs: generate-matrix
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
+    name: ${{ matrix.config.name }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: "3.8"
       - name: Install Conan
         run: |
           pip install bincrafters_package_tools
@@ -91,11 +74,9 @@ jobs:
             clang++ --version
           fi
         shell: bash
-        if: env.recipeType == matrix.config.recipeType
       - name: Run
         env:
           CONAN_LOGIN_USERNAME: ${{ secrets.CONAN_LOGIN_USERNAME }}
           CONAN_PASSWORD: ${{ secrets.CONAN_PASSWORD }}
         run: |
           bincrafters-package-tools --auto
-        if: env.recipeType == matrix.config.recipeType

--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -1,4 +1,4 @@
-# bincrafters-conventions:gha-workflow-version:3
+# bincrafters-conventions:gha-workflow-version:4
 # You can add custom environment variables above the version tag
 # Do not modify the tag or anything below the tag
 # This script gets automatically updated
@@ -6,6 +6,7 @@
 # Possible configurations:
 # env:
 #   splitByBuildTypes: "false"  # Possible values "false", "true", default: false
+#   recipeType: "" # Possible values "" (for libraries), "header_only", "installer": default ""
 
 # - IMPORTANT NOTICE: These configurations are actually not completely working as expected yet due to GHA limitations
 # but it is important to set this values already so they can be consumed later
@@ -15,93 +16,86 @@
 on: [push, pull_request]
 
 jobs:
-  # splitByBuildTypesFalse:
-  #   runs-on: ubuntu-18.04
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       compiler:
-  #       - { name: "GCC", version: "4.9"   }
-  #       - { name: "GCC", version: "5"     }
-  #       - { name: "GCC", version: "6"     }
-  #       - { name: "GCC", version: "7"     }
-  #       - { name: "GCC", version: "8"     }
-  #       - { name: "GCC", version: "9"     }
-  #       - { name: "CLANG", version: "3.9" }
-  #       - { name: "CLANG", version: "4.0" }
-  #       - { name: "CLANG", version: "5.0" }
-  #       - { name: "CLANG", version: "6.0" }
-  #       - { name: "CLANG", version: "7.0" }
-  #       - { name: "CLANG", version: "8"   }
-  #       - { name: "CLANG", version: "9"   }
-  #   name: ${{ matrix.compiler.name }} ${{ matrix.compiler.version }}
-  #   if: ${{ env.splitByBuildTypes }} != 'true'
-  #   steps:
-  #     - uses: actions/checkout@v1
-  #     - uses: actions/setup-python@v1
-  #       with:
-  #         python-version: '3.8'
-  #     - name: Install Conan
-  #       run: |
-  #         pip install bincrafters_package_tools
-  #         conan user
-  #     - name: Run
-  #       env:
-  #         CONAN_USE_DOCKER: 1
-  #         CONAN_LOGIN_USERNAME: ${{ secrets.CONAN_LOGIN_USERNAME }}
-  #         CONAN_PASSWORD: ${{ secrets.CONAN_PASSWORD }}
-  #       run: |
-  #         export CONAN_${{ matrix.compiler.name }}_VERSIONS="${{ matrix.compiler.version }}"
-  #         bincrafters-package-tools --auto
-  splitByBuildTypesTrue:
-    runs-on: ubuntu-18.04
+  conan:
+    runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false
       matrix:
-        compiler:
-        - { name: "GCC", version: "4.9", buildType: "Debug"     }
-        - { name: "GCC", version: "4.9", buildType: "Release"   }
-        - { name: "GCC", version: "5", buildType: "Debug"       }
-        - { name: "GCC", version: "5", buildType: "Release"     }
-        - { name: "GCC", version: "6", buildType: "Debug"       }
-        - { name: "GCC", version: "6", buildType: "Release"     }
-        - { name: "GCC", version: "7", buildType: "Debug"       }
-        - { name: "GCC", version: "7", buildType: "Release"     }
-        - { name: "GCC", version: "8", buildType: "Debug"       }
-        - { name: "GCC", version: "8", buildType: "Release"     }
-        - { name: "GCC", version: "9", buildType: "Debug"       }
-        - { name: "GCC", version: "9", buildType: "Release"     }
-        - { name: "CLANG", version: "3.9", buildType: "Debug"   }
-        - { name: "CLANG", version: "3.9", buildType: "Release" }
-        - { name: "CLANG", version: "4.0", buildType: "Debug"   }
-        - { name: "CLANG", version: "4.0", buildType: "Release" }
-        - { name: "CLANG", version: "5.0", buildType: "Debug"   }
-        - { name: "CLANG", version: "5.0", buildType: "Release" }
-        - { name: "CLANG", version: "6.0", buildType: "Debug"   }
-        - { name: "CLANG", version: "6.0", buildType: "Release" }
-        - { name: "CLANG", version: "7.0", buildType: "Debug"   }
-        - { name: "CLANG", version: "7.0", buildType: "Release" }
-        - { name: "CLANG", version: "8", buildType: "Debug"     }
-        - { name: "CLANG", version: "8", buildType: "Release"   }
-        - { name: "CLANG", version: "9", buildType: "Debug"     }
-        - { name: "CLANG", version: "9", buildType: "Release"   }
-    name: ${{ matrix.compiler.name }} ${{ matrix.compiler.version }} ${{ matrix.compiler.buildType }}
-    # if: ${{ env.splitByBuildTypes }} == 'true'
+        config:
+          - { name: "GCC 4.9 Debug", compiler: "GCC", version: "4.9", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
+          - { name: "GCC 4.9 Release", compiler: "GCC", version: "4.9", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
+          - { name: "GCC 5 Debug", compiler: "GCC", version: "5", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
+          - { name: "GCC 5 Release", compiler: "GCC", version: "5", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
+          - { name: "GCC 6 Debug", compiler: "GCC", version: "6", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
+          - { name: "GCC 6 Release", compiler: "GCC", version: "6", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
+          - { name: "GCC 7 Debug", compiler: "GCC", version: "7", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
+          - { name: "GCC 7 Release", compiler: "GCC", version: "7", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
+          - { name: "GCC 8 Debug", compiler: "GCC", version: "8", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
+          - { name: "GCC 8 Release", compiler: "GCC", version: "8", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
+          - { name: "GCC 9 Debug", compiler: "GCC", version: "9", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
+          - { name: "GCC 9 Release", compiler: "GCC", version: "9", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
+          - { name: "CLANG 3.9 Debug", compiler: "CLANG", version: "3.9", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
+          - { name: "CLANG 3.9 Release", compiler: "CLANG", version: "3.9", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
+          - { name: "CLANG 4.0 Debug", compiler: "CLANG", version: "4.0", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
+          - { name: "CLANG 4.0 Release", compiler: "CLANG", version: "4.0", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
+          - { name: "CLANG 5.0 Debug", compiler: "CLANG", version: "5.0", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
+          - { name: "CLANG 5.0 Release", compiler: "CLANG", version: "5.0", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
+          - { name: "CLANG 6.0 Debug", compiler: "CLANG", version: "6.0", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
+          - { name: "CLANG 6.0 Release", compiler: "CLANG", version: "6.0", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
+          - { name: "CLANG 7.0 Debug", compiler: "CLANG", version: "7.0", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
+          - { name: "CLANG 7.0 Release", compiler: "CLANG", version: "7.0", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
+          - { name: "CLANG 8 Debug", compiler: "CLANG", version: "8", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
+          - { name: "CLANG 8 Release", compiler: "CLANG", version: "8", os: "ubuntu-18.04", buildType: "Release", recipeType: "" }
+          - { name: "CLANG 9 Debug", compiler: "CLANG", version: "9", os: "ubuntu-18.04", buildType: "Debug", recipeType: "" }
+          - { name: "CLANG 9 Release", compiler: "CLANG", version: "9", os: "ubuntu-18.04", buildType: "Release", recipeType: ""  }
+          - { name: "Header-only Linux", compiler: "CLANG", version: "8", os: "ubuntu-18.04", recipeType: "header_only" }
+          - { name: "Header-only Windows", compiler: "VISUAL", version: "16", os: "windows-latest", recipeType: "header_only" }
+          - { name: "Installer Linux", compiler: "GCC", version: "7", os: "ubuntu-18.04", dockerImage: "conanio/gcc7-centos6", recipeType: "installer" }
+          - { name: "Installer Windows", compiler: "VISUAL", version: "16", os: "windows-2019", recipeType: "installer" }
+          - { name: "Installer macOS", compiler: "APPLE_CLANG", version: "11.0", os: "macos-10.15", recipeType: "installer" }
+    name: ${{ matrix.config.name }}
+    # # FIXME: GHA will support accessing env variables here in the future
+    # if: (env.splitByBuildTypes != 'true' or matrix.buildType != '') and env.recipeType == matrix.config.recipeType
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        if: env.recipeType == matrix.config.recipeType
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.8'
+          python-version: "3.8"
+        if: env.recipeType == matrix.config.recipeType
       - name: Install Conan
         run: |
-          pip install bincrafters-package-tools
+          pip install bincrafters_package_tools
           conan user
+          echo "::set-env name=CONAN_${{ matrix.config.compiler }}_VERSIONS::${{ matrix.config.version }}"
+          echo "export CONAN_${{ matrix.config.compiler }}_VERSIONS=${{ matrix.config.version }}"
+          compiler="${{ matrix.config.compiler }}"
+          version="${{ matrix.config.version }}"
+          docker_image="${{ matrix.config.dockerImage }}"
+          if [[ "${compiler}" == "GCC" ]] || [[ "${compiler}" == "CLANG" ]]; then
+            if [[ "${docker_image}" == "" ]]; then
+              compiler_lower="${compiler,,}"
+              version_withoutdot="${version//./}"
+              docker_image="conanio/${compiler_lower}${version_withoutdot}"
+            fi
+            echo "::set-env name=CONAN_DOCKER_IMAGE::${docker_image}"
+            echo "export CONAN_DOCKER_IMAGE=${docker_image}"
+          fi
+          build_type="${{ matrix.config.buildType }}"
+          if ! [[ "${build_type}" == "" ]]; then
+            echo "::set-env name=CONAN_BUILD_TYPES::${build_type}"
+            echo "export CONAN_BUILD_TYPES=${build_type}"
+          fi
+          if [[ "${compiler}" == "APPLE_CLANG" ]] && [[ "${version}" == "11.0" ]]; then
+            sudo xcode-select -switch "/Applications/Xcode_11.3.1.app"
+            clang++ --version
+          fi
+        shell: bash
+        if: env.recipeType == matrix.config.recipeType
       - name: Run
         env:
-          CONAN_USE_DOCKER: 1
           CONAN_LOGIN_USERNAME: ${{ secrets.CONAN_LOGIN_USERNAME }}
           CONAN_PASSWORD: ${{ secrets.CONAN_PASSWORD }}
-          CONAN_BUILD_TYPES: ${{ matrix.compiler.buildType }}
         run: |
-          export CONAN_${{ matrix.compiler.name }}_VERSIONS="${{ matrix.compiler.version }}"
           bincrafters-package-tools --auto
+        if: env.recipeType == matrix.config.recipeType

--- a/conanfile.py
+++ b/conanfile.py
@@ -95,7 +95,7 @@ class SDL2Conan(ConanFile):
                 self.requires.add("xkbcommon/0.9.1@bincrafters/stable")
             if self.options.pulse:
                 self.requires("pulseaudio/13.0@bincrafters/stable")
-            self.requires("mesa/19.3.1@bincrafters/stable")
+            self.requires("opengl/virtual@bincrafters/stable")
 
     def system_requirements(self):
         if self.settings.os == "Linux" and tools.os_info.is_linux:

--- a/conanfile.py
+++ b/conanfile.py
@@ -172,7 +172,7 @@ class SDL2Conan(ConanFile):
             self.options.remove("directx")
             self.options.remove("render_d3d")
 
-        if self.settings.os != "Macos": # iOS/tvOS/... ?
+        if not tools.is_apple_os():
             self.options.remove("render_metal")
             self.options.remove("video_metal")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -279,7 +279,7 @@ class SDL2Conan(ConanFile):
                 self._cmake.definitions["DIRECTX"] = self.options.directx
                 self._cmake.definitions["RENDER_D3D"] = self.options.render_d3d
 
-            elif self.settings.os == "Macos":# TODO: ios, tvos, ... ?
+            elif tools.is_apple_os():
 
                 if self.options.video_metal:
                     self._cmake.definitions['HAVE_FRAMEWORK_METAL'] = True


### PR DESCRIPTION
Here are a few options that seem to be missing from the configuration.

I've been experimenting in using conan for some our builds, and MacOS was first.
Unfortunately the default (and required for MacOS) metal renderer was disabled.

See the diff between the previous SDL release and 2.0.12 here: https://fossies.org/diffs/SDL2/2.0.10_vs_2.0.12/CMakeLists.txt-diff.html

Added these options:
- video_metal
- render_metal
- video_offscreen
- armsimd
- armneon
- render_d3d

Added these frameworks:
- AVFoundation
- Metal

Note: I'm still testing this to see if I've done it correctly :)

- The existing options seem to shorten the ones used in the cmake file, which I couldn't do for video_metal, and render_metal.
- I couldn't see how to add documentation for the options. 
