### PR TITLE
Correct the package name used by "cmake_find_package(_multi)"

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -330,3 +330,5 @@ class SDL2Conan(ConanFile):
             self.cpp_info.frameworks.extend(['Cocoa', 'Carbon', 'IOKit', 'CoreVideo', 'CoreAudio', 'AudioToolbox', 'ForceFeedback'])
         elif self.settings.os == "Windows":
             self.cpp_info.system_libs.extend(['user32', 'gdi32', 'winmm', 'imm32', 'ole32', 'oleaut32', 'version', 'uuid', 'advapi32', 'setupapi', 'shell32'])
+        self.cpp_info.names["cmake_find_package"] = "SDL2"
+        self.cpp_info.names["cmake_find_package_multi"] = "SDL2"


### PR DESCRIPTION
By default, Conan's `cmake_find_package` and `cmake_find_package_multi` generators use the package's name to generate variables and targets defined in Find***.cmake.
In this case, it means variables are called `sdl2_FOOBAR` and the target is called `sdl2::sdl2`.
This PR changes the name used so it generates `SDL2_FOOBAR` and `SDL2::SDL2` instead.
This matches the behavior of the sdl2-config.cmake created by SDL2 when installed from upstream.