### PR TITLE
sdl2main false option no longer exports sdl2main again

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -294,7 +294,7 @@ class SDL2Conan(ConanFile):
         self.env_info.SDL_CONFIG = sdl2_config
         self.cpp_info.libs = [lib for lib in tools.collect_libs(self) if "2.0" not in lib]
         if not self.options.sdl2main:
-            self.cpp_info.libs = [lib for lib in self.cpp_info.libs]
+            self.cpp_info.libs = [lib for lib in self.cpp_info.libs if 'main' not in lib]
         else:
             # ensure that SDL2main is linked first
             sdl2mainlib = "SDL2main"


### PR DESCRIPTION
I think this commit regressed the sdl2main option: https://github.com/bincrafters/conan-sdl2/commit/bcaa72724f9d2486f07ffa5e806b26f365352898

I'm noticing that with sdl2main option set as false, sdl2main.lib is still being exported and linked to projects.
